### PR TITLE
fix: use direct database access instead of URL callbacks

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,6 +45,8 @@ export default [
         describe: 'readonly',
         it: 'readonly',
         expect: 'readonly',
+        beforeAll: 'readonly',
+        afterAll: 'readonly',
         beforeEach: 'readonly',
         afterEach: 'readonly',
         jest: 'readonly',

--- a/src/__tests__/drafts-db.test.ts
+++ b/src/__tests__/drafts-db.test.ts
@@ -1,0 +1,173 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { DraftsDatabase } from '../drafts-db.js';
+
+const execFileAsync = promisify(execFile);
+
+// These tests run the real sqlite3 CLI (as the implementation does) against a
+// throwaway database that mirrors the relevant ZMANAGEDDRAFT columns.
+describe('DraftsDatabase', () => {
+  let tmpDir: string;
+  let dbPath: string;
+  let db: DraftsDatabase;
+
+  beforeAll(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'drafts-db-test-'));
+    dbPath = join(tmpDir, 'DraftStore.sqlite');
+
+    const setup = `
+      CREATE TABLE ZMANAGEDDRAFT (
+        ZUUID TEXT,
+        ZTITLE TEXT,
+        ZCONTENT TEXT,
+        ZCACHED_TAGS TEXT,
+        ZCREATED_AT REAL,
+        ZMODIFIED_AT REAL,
+        ZFLAGGED INTEGER,
+        ZFOLDER INTEGER
+      );
+      INSERT INTO ZMANAGEDDRAFT VALUES
+        ('uuid-title', 'Explicit Title', 'Body one' || CHAR(10) || 'Body two', 'work,personal', 0, 100, 1, 0),
+        ('uuid-multiline', '', 'First line title' || CHAR(10) || 'second line', 'ideas', 0, 90, 0, 0),
+        ('uuid-singleline', '', 'Single line only', '', 0, 80, 0, 1),
+        ('uuid-empty', '', '', NULL, 0, 70, 0, 2),
+        ('uuid-nulls', NULL, NULL, NULL, 0, 60, 0, 0);
+    `;
+    await execFileAsync('sqlite3', [dbPath, setup]);
+    db = new DraftsDatabase(dbPath);
+  });
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('getAllDrafts title extraction', () => {
+    it('uses ZTITLE when it is present', async () => {
+      const drafts = await db.getAllDrafts();
+      expect(drafts.find((d) => d.uuid === 'uuid-title')?.title).toBe('Explicit Title');
+    });
+
+    it('extracts the first line when ZTITLE is empty and content has newlines', async () => {
+      const drafts = await db.getAllDrafts();
+      expect(drafts.find((d) => d.uuid === 'uuid-multiline')?.title).toBe('First line title');
+    });
+
+    it('uses the whole content when ZTITLE is empty and content has no newline', async () => {
+      const drafts = await db.getAllDrafts();
+      expect(drafts.find((d) => d.uuid === 'uuid-singleline')?.title).toBe('Single line only');
+    });
+
+    it('returns an empty title when both ZTITLE and content are empty', async () => {
+      const drafts = await db.getAllDrafts();
+      expect(drafts.find((d) => d.uuid === 'uuid-empty')?.title).toBe('');
+    });
+
+    it('returns an empty title when ZTITLE and content are null', async () => {
+      const drafts = await db.getAllDrafts();
+      expect(drafts.find((d) => d.uuid === 'uuid-nulls')?.title).toBe('');
+    });
+  });
+
+  describe('getAllDrafts metadata mapping', () => {
+    it('orders results by modified date descending', async () => {
+      const drafts = await db.getAllDrafts();
+      expect(drafts.map((d) => d.uuid)).toEqual([
+        'uuid-title',
+        'uuid-multiline',
+        'uuid-singleline',
+        'uuid-empty',
+        'uuid-nulls',
+      ]);
+    });
+
+    it('parses tags, flags and timestamps', async () => {
+      const drafts = await db.getAllDrafts();
+      const draft = drafts.find((d) => d.uuid === 'uuid-title')!;
+      expect(draft.tags).toEqual(['work', 'personal']);
+      expect(draft.isFlagged).toBe(true);
+      expect(draft.isArchived).toBe(false);
+      expect(draft.isTrashed).toBe(false);
+      expect(draft.createdAt).toBe('2001-01-01T00:00:00.000Z');
+    });
+
+    it('maps archive and trash folders', async () => {
+      const drafts = await db.getAllDrafts();
+      expect(drafts.find((d) => d.uuid === 'uuid-singleline')?.isArchived).toBe(true);
+      expect(drafts.find((d) => d.uuid === 'uuid-empty')?.isTrashed).toBe(true);
+    });
+
+    it('returns empty tags when ZCACHED_TAGS is null', async () => {
+      const drafts = await db.getAllDrafts();
+      expect(drafts.find((d) => d.uuid === 'uuid-empty')?.tags).toEqual([]);
+    });
+  });
+
+  describe('getAllDrafts filtering', () => {
+    it('filters by inbox folder', async () => {
+      const drafts = await db.getAllDrafts({ folder: 'inbox' });
+      expect(drafts.map((d) => d.uuid).sort()).toEqual([
+        'uuid-multiline',
+        'uuid-nulls',
+        'uuid-title',
+      ]);
+    });
+
+    it('filters by archive folder', async () => {
+      const drafts = await db.getAllDrafts({ folder: 'archive' });
+      expect(drafts.map((d) => d.uuid)).toEqual(['uuid-singleline']);
+    });
+
+    it('filters by trash folder', async () => {
+      const drafts = await db.getAllDrafts({ folder: 'trash' });
+      expect(drafts.map((d) => d.uuid)).toEqual(['uuid-empty']);
+    });
+
+    it('filters by flagged state', async () => {
+      const drafts = await db.getAllDrafts({ flagged: true });
+      expect(drafts.map((d) => d.uuid)).toEqual(['uuid-title']);
+    });
+  });
+
+  describe('searchDrafts', () => {
+    it('extracts the first line as the title in results', async () => {
+      const results = await db.searchDrafts('First line');
+      expect(results.find((d) => d.uuid === 'uuid-multiline')?.title).toBe('First line title');
+    });
+
+    it('matches against ZTITLE', async () => {
+      const results = await db.searchDrafts('Explicit');
+      expect(results.map((d) => d.uuid)).toContain('uuid-title');
+    });
+
+    it('returns an empty array when nothing matches', async () => {
+      const results = await db.searchDrafts('zzz-no-match-zzz');
+      expect(results).toEqual([]);
+    });
+
+    it('escapes single quotes in the search text', async () => {
+      const results = await db.searchDrafts("o'brien");
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe('getDraftContent', () => {
+    it('returns the full content for an existing uuid', async () => {
+      expect(await db.getDraftContent('uuid-multiline')).toBe('First line title\nsecond line');
+    });
+
+    it('returns an empty string for empty content', async () => {
+      expect(await db.getDraftContent('uuid-empty')).toBe('');
+    });
+
+    it('returns an empty string for null content', async () => {
+      expect(await db.getDraftContent('uuid-nulls')).toBe('');
+    });
+
+    it('returns null for a non-existent uuid', async () => {
+      expect(await db.getDraftContent('does-not-exist')).toBeNull();
+    });
+  });
+});

--- a/src/drafts-db.ts
+++ b/src/drafts-db.ts
@@ -59,10 +59,16 @@ export class DraftsDatabase {
       whereClause = 'WHERE ' + conditions.join(' AND ');
     }
 
+    // PATCHED: Extract title from first line of ZCONTENT since ZTITLE is often empty
+    // Drafts displays the first line as the title in its UI
     const query = `
       SELECT
         ZUUID as uuid,
-        ZTITLE as title,
+        CASE 
+          WHEN ZTITLE IS NOT NULL AND ZTITLE != '' THEN ZTITLE
+          WHEN INSTR(ZCONTENT, CHAR(10)) > 0 THEN SUBSTR(ZCONTENT, 1, INSTR(ZCONTENT, CHAR(10)) - 1)
+          ELSE ZCONTENT
+        END as title,
         ZCACHED_TAGS as tags,
         ZCREATED_AT as createdAt,
         ZMODIFIED_AT as modifiedAt,
@@ -115,11 +121,16 @@ export class DraftsDatabase {
     }
   }
 
+  // PATCHED: Also extract title from first line in search results
   async searchDrafts(searchText: string): Promise<DraftMetadata[]> {
     const query = `
       SELECT
         ZUUID as uuid,
-        ZTITLE as title,
+        CASE 
+          WHEN ZTITLE IS NOT NULL AND ZTITLE != '' THEN ZTITLE
+          WHEN INSTR(ZCONTENT, CHAR(10)) > 0 THEN SUBSTR(ZCONTENT, 1, INSTR(ZCONTENT, CHAR(10)) - 1)
+          ELSE ZCONTENT
+        END as title,
         ZCACHED_TAGS as tags,
         ZCREATED_AT as createdAt,
         ZMODIFIED_AT as modifiedAt,

--- a/src/drafts-db.ts
+++ b/src/drafts-db.ts
@@ -29,6 +29,13 @@ export class DraftsDatabase {
     return new Date(unixTimestamp * 1000).toISOString();
   }
 
+  // sqlite3 -json emits an empty string (not "[]") when no rows match,
+  // so guard against parsing that as JSON.
+  private parseRows(stdout: string): any[] {
+    const trimmed = stdout.trim();
+    return trimmed ? JSON.parse(trimmed) : [];
+  }
+
   async getAllDrafts(options?: {
     folder?: 'inbox' | 'archive' | 'trash' | 'all';
     flagged?: boolean;
@@ -59,12 +66,12 @@ export class DraftsDatabase {
       whereClause = 'WHERE ' + conditions.join(' AND ');
     }
 
-    // PATCHED: Extract title from first line of ZCONTENT since ZTITLE is often empty
-    // Drafts displays the first line as the title in its UI
+    // ZTITLE is usually empty; Drafts derives the display title from the first
+    // line of content, so fall back to the first line (or whole content) of ZCONTENT.
     const query = `
       SELECT
         ZUUID as uuid,
-        CASE 
+        CASE
           WHEN ZTITLE IS NOT NULL AND ZTITLE != '' THEN ZTITLE
           WHEN INSTR(ZCONTENT, CHAR(10)) > 0 THEN SUBSTR(ZCONTENT, 1, INSTR(ZCONTENT, CHAR(10)) - 1)
           ELSE ZCONTENT
@@ -82,9 +89,9 @@ export class DraftsDatabase {
     try {
       const { stdout } = await execFileAsync('sqlite3', [this.dbPath, '-json', query]);
 
-      const results = JSON.parse(stdout);
+      const results = this.parseRows(stdout);
 
-      return results.map((row: any) => ({
+      return results.map((row) => ({
         uuid: row.uuid,
         title: row.title || '',
         tags: row.tags ? row.tags.split(',').filter((t: string) => t.trim()) : [],
@@ -109,7 +116,7 @@ export class DraftsDatabase {
     try {
       const { stdout } = await execFileAsync('sqlite3', [this.dbPath, '-json', query]);
 
-      const results = JSON.parse(stdout);
+      const results = this.parseRows(stdout);
 
       if (results.length === 0) {
         return null;
@@ -121,12 +128,12 @@ export class DraftsDatabase {
     }
   }
 
-  // PATCHED: Also extract title from first line in search results
   async searchDrafts(searchText: string): Promise<DraftMetadata[]> {
+    // Same first-line title fallback as getAllDrafts (see comment there).
     const query = `
       SELECT
         ZUUID as uuid,
-        CASE 
+        CASE
           WHEN ZTITLE IS NOT NULL AND ZTITLE != '' THEN ZTITLE
           WHEN INSTR(ZCONTENT, CHAR(10)) > 0 THEN SUBSTR(ZCONTENT, 1, INSTR(ZCONTENT, CHAR(10)) - 1)
           ELSE ZCONTENT
@@ -145,9 +152,9 @@ export class DraftsDatabase {
     try {
       const { stdout } = await execFileAsync('sqlite3', [this.dbPath, '-json', query]);
 
-      const results = JSON.parse(stdout);
+      const results = this.parseRows(stdout);
 
-      return results.map((row: any) => ({
+      return results.map((row) => ({
         uuid: row.uuid,
         title: row.title || '',
         tags: row.tags ? row.tags.split(',').filter((t: string) => t.trim()) : [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -406,9 +406,3 @@ server.start().catch((error) => {
   console.error('Failed to start server:', error);
   process.exit(1);
 });
-
-
-
-
-
-


### PR DESCRIPTION
## Problem

When using `get_draft` (reading drafts by UUID), the MCP server triggers 
`drafts://` URL callbacks via the macOS `open` command. This causes:

  - Browser/app picker dialogs (e.g., OpenIn) intercepting the localhost callback URL
  - Default browser opening localhost callback URLs when no picker is installed
  - Broken automation when no user is present to dismiss dialogs

## Root Cause

The `DraftsClient` class uses x-callback-url schemes which require user 
interaction. The `DraftsDatabase` class already had direct SQLite access 
but wasn't being used for single-draft retrieval.

## Additional Fix: Empty Titles

The original `getAllDrafts` and `searchDrafts` queries returned empty titles 
because `ZTITLE` is always empty in the Drafts SQLite database. Drafts 
calculates the display title dynamically from the first line of content. 
This caused the MCP to return UUIDs instead of actual draft titles.

## Changes

- `get_draft`: use `draftsDb.getDraftContent()` instead of `draftsClient.getDraft()`
- Resource handler: same fix for `draft://uuid/{uuid}` resources  
- `getAllDrafts`/`searchDrafts`: extract title from first line of `ZCONTENT`

Write operations (create, append, prepend) still use URL callbacks as those 
require Drafts app integration.