### PR TITLE
docs(readme): add security + triage + tool guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,15 @@ Then point your client at the built entry point:
 
 ---
 
+## Something not working?
+
+1. **Creating / appending / opening drafts does nothing?** Make sure the **Drafts app is running** — write actions go through Drafts' URL scheme. Reading and searching work even when Drafts is closed.
+2. **First write seems to hang?** macOS may show a prompt asking to let your AI tool open Drafts — approve it and try again.
+3. **Reads fail?** Confirm Drafts is installed and you can open `~/Library/Group Containers/GTFQ98J4YG.com.agiletortoise.Drafts/`.
+4. Still stuck? See [Troubleshooting](#troubleshooting) below.
+
+---
+
 ## Tools
 
 | Tool | What it does |
@@ -171,6 +180,15 @@ drafts-mcp --help       Show help
 drafts-mcp --version    Print version
 ```
 
+## Security
+
+Everything runs locally on your Mac:
+
+- **Reads** query the local Drafts SQLite database directly — no app, network, or cloud involved.
+- **Writes** hand a `drafts://x-callback-url` to the macOS `open` command; Drafts then calls back into a short-lived HTTP server the MCP server starts on a random port.
+- That callback server lives only while the MCP server is running and only completes requests keyed by an unguessable `randomUUID()` it generated itself. It holds no credentials and carries nothing beyond Drafts' own callback payload.
+- No auth tokens, no telemetry, no remote endpoints — your drafts never leave your machine.
+
 ## Requirements
 
 - **macOS** — the server shells out to `open` for URL schemes and reads the macOS Drafts group container.
@@ -200,6 +218,17 @@ Repo layout:
 ### Releasing
 
 Run the **Release** workflow (`.github/workflows/release.yml`) via *Actions → Release → Run workflow*. It bumps every version source, tags, builds the `.mcpb` + binaries + npm tarball, publishes to npm (OIDC trusted publishing), and creates the GitHub release.
+
+## Adding a new tool
+
+A tool lives in **three** hand-kept places in `src/index.ts` plus its implementation — keep them in sync:
+
+1. Define a `zod` schema for the arguments.
+2. Add a tool entry (name, description, hand-written JSON Schema `inputSchema`) to the `ListToolsRequestSchema` handler — keep it identical to the zod shape.
+3. Add a `case` to the `CallToolRequestSchema` switch that parses with the zod schema and calls the implementation.
+4. Implement the operation in `DraftsDatabase` (reads) or `DraftsClient` (writes) — never inline SQLite/URL logic in `index.ts`.
+5. Add a spec under `src/__tests__/` (read tools run against a throwaway SQLite DB).
+6. Add a row to the [Tools](#tools) table above.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Motivation

Bring the drafts-mcp README to parity with the sibling lightroom-mcp
README by adding the three sections it was missing.

> Changelog: skip

## Implementation information

- **Something not working?** — a short quick-triage block placed right
  after the install paths (Drafts must be running for writes, macOS
  open-permission prompt, read/DB path check), linking to Troubleshooting.
- **Security** — accurate local-only model: reads hit the local SQLite
  DB directly; writes go through the macOS `open` command; the callback
  server is short-lived, on a random port, and only completes requests
  keyed by an unguessable `randomUUID()` it generated. No tokens or
  telemetry. (Deliberately does not claim localhost-only binding — the
  server currently uses `listen(port)`, which binds all interfaces.)
- **Adding a new tool** — contributor guide mirroring the project's
  three-in-sync-sites pattern (zod schema / ListTools JSON Schema /
  switch case) plus implementation in DraftsDatabase/DraftsClient and a
  test.

Docs-only; no code changes.

## Supporting documentation

Mirrors the section set in the sibling `lightroom-mcp` README.