### PR TITLE
fix(client): encode write-path spaces as %20

### DIFF
--- a/src/__tests__/drafts-client.test.ts
+++ b/src/__tests__/drafts-client.test.ts
@@ -27,6 +27,45 @@ describe('encodeQueryParams', () => {
   });
 });
 
+// Captures the drafts:// URL buildUrl produces, so we can assert the real
+// write path (not just the helper) encodes spaces as %20.
+class UrlCapturingClient extends DraftsClient {
+  public lastUrl = '';
+  protected async openUrl(url: string): Promise<Record<string, string>> {
+    this.lastUrl = url;
+    return {};
+  }
+}
+
+describe('DraftsClient buildUrl encoding', () => {
+  let callbackServer: CallbackServer;
+  let client: UrlCapturingClient;
+
+  beforeEach(async () => {
+    callbackServer = new CallbackServer();
+    await callbackServer.start();
+    client = new UrlCapturingClient(callbackServer, { maxRetries: 1, retryDelay: 10 });
+  });
+
+  afterEach(async () => {
+    await callbackServer.stop();
+  });
+
+  it('encodes spaces in createDraft as %20 with no literal +', async () => {
+    await client.createDraft({ text: 'hello world', tags: ['a b', 'c'] });
+    expect(client.lastUrl).toContain('drafts://x-callback-url/create?');
+    expect(client.lastUrl).toContain('text=hello%20world');
+    expect(client.lastUrl).toContain('tag=a%20b&tag=c');
+    expect(client.lastUrl.split('?')[1]).not.toContain('+');
+  });
+
+  it('encodes spaces in appendToDraft text', async () => {
+    await client.appendToDraft('UUID-1', 'APPENDED line with spaces');
+    expect(client.lastUrl).toContain('text=APPENDED%20line%20with%20spaces');
+    expect(client.lastUrl.split('?')[1]).not.toContain('+');
+  });
+});
+
 describe('DraftsClient', () => {
   let callbackServer: CallbackServer;
   let draftsClient: DraftsClient;

--- a/src/__tests__/drafts-client.test.ts
+++ b/src/__tests__/drafts-client.test.ts
@@ -1,5 +1,31 @@
-import { DraftsClient } from '../drafts-client.js';
+import { DraftsClient, encodeQueryParams } from '../drafts-client.js';
 import { CallbackServer } from '../callback-server.js';
+
+describe('encodeQueryParams', () => {
+  it('encodes spaces as %20, not + (Drafts decodes + literally)', () => {
+    expect(encodeQueryParams({ text: 'hello world' })).toBe('text=hello%20world');
+  });
+
+  it('preserves a literal plus as %2B', () => {
+    expect(encodeQueryParams({ text: 'a + b' })).toBe('text=a%20%2B%20b');
+  });
+
+  it('repeats the key for array values', () => {
+    expect(encodeQueryParams({ tag: ['mcp test', 'automated'] })).toBe(
+      'tag=mcp%20test&tag=automated'
+    );
+  });
+
+  it('stringifies booleans and skips undefined values', () => {
+    expect(encodeQueryParams({ flagged: true, missing: undefined, name: 'x' })).toBe(
+      'flagged=true&name=x'
+    );
+  });
+
+  it('percent-encodes reserved characters left alone by encodeURIComponent', () => {
+    expect(encodeQueryParams({ q: "it's (a) test!" })).toBe('q=it%27s%20%28a%29%20test%21');
+  });
+});
 
 describe('DraftsClient', () => {
   let callbackServer: CallbackServer;

--- a/src/drafts-client.ts
+++ b/src/drafts-client.ts
@@ -71,7 +71,7 @@ export class DraftsClient {
   private buildUrl(
     endpoint: string,
     params: Record<string, string | string[] | boolean | undefined>
-  ): string {
+  ): { url: string; requestId: string } {
     const requestId = randomUUID();
     const callbacks = this.callbackServer.getCallbackUrls(requestId);
 
@@ -85,10 +85,10 @@ export class DraftsClient {
     return {
       url: `drafts://x-callback-url/${endpoint}?${query}`,
       requestId,
-    } as any;
+    };
   }
 
-  private async openUrl(url: string, requestId: string): Promise<Record<string, string>> {
+  protected async openUrl(url: string, requestId: string): Promise<Record<string, string>> {
     const responsePromise = this.callbackServer.registerRequest(requestId);
 
     await execFileAsync('open', [url]);
@@ -114,7 +114,7 @@ export class DraftsClient {
         tag: params.tags,
         action: params.action,
         folder: params.folder,
-      }) as any;
+      });
 
       await this.openUrl(url, requestId);
     });
@@ -124,7 +124,7 @@ export class DraftsClient {
     return this.executeWithRetry(async () => {
       const { url, requestId } = this.buildUrl('get', {
         uuid,
-      }) as any;
+      });
 
       const response = await this.openUrl(url, requestId);
 
@@ -156,7 +156,7 @@ export class DraftsClient {
       const { url, requestId } = this.buildUrl('append', {
         uuid,
         text,
-      }) as any;
+      });
 
       await this.openUrl(url, requestId);
     });
@@ -167,7 +167,7 @@ export class DraftsClient {
       const { url, requestId } = this.buildUrl('prepend', {
         uuid,
         text,
-      }) as any;
+      });
 
       await this.openUrl(url, requestId);
     });
@@ -182,7 +182,7 @@ export class DraftsClient {
       const { url, requestId } = this.buildUrl('open', {
         uuid: params.uuid,
         title: params.title,
-      }) as any;
+      });
 
       await this.openUrl(url, requestId);
     });
@@ -193,7 +193,7 @@ export class DraftsClient {
       const { url, requestId } = this.buildUrl('runAction', {
         action: actionName,
         text,
-      }) as any;
+      });
 
       await this.openUrl(url, requestId);
     });
@@ -209,7 +209,7 @@ export class DraftsClient {
         query: params.query,
         tag: params.tag,
         folder: params.folder,
-      }) as any;
+      });
 
       await this.openUrl(url, requestId);
     });

--- a/src/drafts-client.ts
+++ b/src/drafts-client.ts
@@ -6,6 +6,37 @@ import { Draft } from './types.js';
 
 const execFileAsync = promisify(execFile);
 
+// encodeURIComponent leaves !'()* unescaped; percent-encode them too so the
+// value is safe inside an x-callback-url query string.
+export function encodeURIComponentSafe(str: string): string {
+  return encodeURIComponent(str).replace(/[!'()*]/g, (c) => {
+    return '%' + c.charCodeAt(0).toString(16).toUpperCase();
+  });
+}
+
+// Build an x-callback-url query string. Unlike URLSearchParams.toString(),
+// this encodes spaces as %20 (not +); Drafts decodes a literal + as +, so
+// URLSearchParams would corrupt every space in the payload.
+export function encodeQueryParams(
+  params: Record<string, string | string[] | boolean | undefined>
+): string {
+  const pairs: string[] = [];
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined) continue;
+
+    const values = Array.isArray(value)
+      ? value
+      : [typeof value === 'boolean' ? value.toString() : value];
+
+    for (const v of values) {
+      pairs.push(`${encodeURIComponentSafe(key)}=${encodeURIComponentSafe(v)}`);
+    }
+  }
+
+  return pairs.join('&');
+}
+
 export interface DraftsClientConfig {
   maxRetries?: number;
   retryDelay?: number;
@@ -37,12 +68,6 @@ export class DraftsClient {
     }
   }
 
-  private encodeURIComponentSafe(str: string): string {
-    return encodeURIComponent(str).replace(/[!'()*]/g, (c) => {
-      return '%' + c.charCodeAt(0).toString(16).toUpperCase();
-    });
-  }
-
   private buildUrl(
     endpoint: string,
     params: Record<string, string | string[] | boolean | undefined>
@@ -50,26 +75,15 @@ export class DraftsClient {
     const requestId = randomUUID();
     const callbacks = this.callbackServer.getCallbackUrls(requestId);
 
-    const urlParams = new URLSearchParams();
-
-    for (const [key, value] of Object.entries(params)) {
-      if (value === undefined) continue;
-
-      if (Array.isArray(value)) {
-        value.forEach((v) => urlParams.append(key, v));
-      } else if (typeof value === 'boolean') {
-        urlParams.append(key, value.toString());
-      } else {
-        urlParams.append(key, value);
-      }
-    }
-
-    urlParams.append('x-success', callbacks.success);
-    urlParams.append('x-error', callbacks.error);
-    urlParams.append('x-cancel', callbacks.cancel);
+    const query = encodeQueryParams({
+      ...params,
+      'x-success': callbacks.success,
+      'x-error': callbacks.error,
+      'x-cancel': callbacks.cancel,
+    });
 
     return {
-      url: `drafts://x-callback-url/${endpoint}?${urlParams.toString()}`,
+      url: `drafts://x-callback-url/${endpoint}?${query}`,
       requestId,
     } as any;
   }


### PR DESCRIPTION
## Motivation

Every write op (`create_draft`, `append_to_draft`, `prepend_to_draft`) stored
spaces as a literal `+`: `hello world` round-tripped as `hello+world`. Root
cause: `buildUrl` serialized params with `URLSearchParams.toString()`, which
form-urlencodes spaces as `+`. The Drafts `x-callback-url` scheme expects
`%20` and decodes a literal `+` as `+`, corrupting every space in the payload.

## Implementation information

- Build the x-callback query string manually via `encodeQueryParams`, which
  percent-encodes through the previously-dead `encodeURIComponentSafe` helper
  (spaces become `%20`; a literal `+` becomes `%2B`).
- Callback URL values (`x-success`/`x-error`/`x-cancel`) encode byte-for-byte
  identically to the old `URLSearchParams` output, so the Express callback
  routes still match — no double/under-encoding regression.
- Tests: unit-cover `encodeQueryParams` (spaces, literal `+`, arrays, booleans,
  reserved chars) and drive the real `buildUrl` path through `createDraft`/
  `appendToDraft`, asserting `%20` and no surviving `+`. The end-to-end test
  guards against a revert to `URLSearchParams`.

Closes #47

> Changelog: fix(client): encode write-path spaces as %20