### PR TITLE
fix(db): parse ZCACHED_TAGS ZZZ tokens

### DIFF
--- a/src/__tests__/drafts-db.test.ts
+++ b/src/__tests__/drafts-db.test.ts
@@ -30,8 +30,8 @@ describe('DraftsDatabase', () => {
         ZFOLDER INTEGER
       );
       INSERT INTO ZMANAGEDDRAFT VALUES
-        ('uuid-title', 'Explicit Title', 'Body one' || CHAR(10) || 'Body two', 'work,personal', 0, 100, 1, 0),
-        ('uuid-multiline', '', 'First line title' || CHAR(10) || 'second line', 'ideas', 0, 90, 0, 0),
+        ('uuid-title', 'Explicit Title', 'Body one' || CHAR(10) || 'Body two', 'ZZZworkZZZ ZZZpersonalZZZ', 0, 100, 1, 0),
+        ('uuid-multiline', '', 'First line title' || CHAR(10) || 'second line', 'ZZZideasZZZ', 0, 90, 0, 0),
         ('uuid-singleline', '', 'Single line only', '', 0, 80, 0, 1),
         ('uuid-empty', '', '', NULL, 0, 70, 0, 2),
         ('uuid-nulls', NULL, NULL, NULL, 0, 60, 0, 0);
@@ -103,6 +103,13 @@ describe('DraftsDatabase', () => {
       const drafts = await db.getAllDrafts();
       expect(drafts.find((d) => d.uuid === 'uuid-empty')?.tags).toEqual([]);
     });
+
+    it('parses ZZZ-wrapped tag tokens without leaking the sentinels', async () => {
+      const drafts = await db.getAllDrafts();
+      const tags = drafts.find((d) => d.uuid === 'uuid-title')!.tags;
+      expect(tags).toEqual(['work', 'personal']);
+      expect(tags.join(' ')).not.toContain('ZZZ');
+    });
   });
 
   describe('getAllDrafts filtering', () => {
@@ -142,6 +149,11 @@ describe('DraftsDatabase', () => {
       expect(results.map((d) => d.uuid)).toContain('uuid-title');
     });
 
+    it('parses ZZZ-wrapped tags in results', async () => {
+      const results = await db.searchDrafts('Explicit');
+      expect(results.find((d) => d.uuid === 'uuid-title')?.tags).toEqual(['work', 'personal']);
+    });
+
     it('returns an empty array when nothing matches', async () => {
       const results = await db.searchDrafts('zzz-no-match-zzz');
       expect(results).toEqual([]);
@@ -150,6 +162,45 @@ describe('DraftsDatabase', () => {
     it('escapes single quotes in the search text', async () => {
       const results = await db.searchDrafts("o'brien");
       expect(results).toEqual([]);
+    });
+  });
+
+  describe('parseCachedTags edge cases', () => {
+    let edgeDir: string;
+    let edgeDb: DraftsDatabase;
+
+    beforeAll(async () => {
+      edgeDir = mkdtempSync(join(tmpdir(), 'drafts-db-tags-'));
+      const p = join(edgeDir, 'DraftStore.sqlite');
+      const setup = `
+        CREATE TABLE ZMANAGEDDRAFT (
+          ZUUID TEXT, ZTITLE TEXT, ZCONTENT TEXT, ZCACHED_TAGS TEXT,
+          ZCREATED_AT REAL, ZMODIFIED_AT REAL, ZFLAGGED INTEGER, ZFOLDER INTEGER
+        );
+        INSERT INTO ZMANAGEDDRAFT VALUES
+          ('t-trailingz', '', 'x', 'ZZZTODOZZZZ', 0, 30, 0, 0),
+          ('t-multiword', '', 'x', 'ZZZread laterZZZ ZZZworkZZZ', 0, 20, 0, 0),
+          ('t-embedded', '', 'x', 'ZZZfooZZZbarZZZ', 0, 10, 0, 0);
+      `;
+      await execFileAsync('sqlite3', [p, setup]);
+      edgeDb = new DraftsDatabase(p);
+    });
+
+    afterAll(() => rmSync(edgeDir, { recursive: true, force: true }));
+
+    it('keeps a trailing uppercase Z in the tag name', async () => {
+      const drafts = await edgeDb.getAllDrafts();
+      expect(drafts.find((d) => d.uuid === 't-trailingz')?.tags).toEqual(['TODOZ']);
+    });
+
+    it('preserves spaces inside a multi-word tag', async () => {
+      const drafts = await edgeDb.getAllDrafts();
+      expect(drafts.find((d) => d.uuid === 't-multiword')?.tags).toEqual(['read later', 'work']);
+    });
+
+    it('keeps a literal ZZZ inside a tag name', async () => {
+      const drafts = await edgeDb.getAllDrafts();
+      expect(drafts.find((d) => d.uuid === 't-embedded')?.tags).toEqual(['fooZZZbar']);
     });
   });
 

--- a/src/drafts-db.ts
+++ b/src/drafts-db.ts
@@ -36,6 +36,16 @@ export class DraftsDatabase {
     return trimmed ? JSON.parse(trimmed) : [];
   }
 
+  // Drafts stores ZCACHED_TAGS as space-separated ZZZ<tag>ZZZ tokens, not a
+  // comma-separated list. The space (or end of string) is the authoritative
+  // separator, so anchor the closing ZZZ to a whitespace/end boundary; keying
+  // purely off ZZZ would truncate a tag ending in Z or split a tag containing
+  // a literal ZZZ. Splitting on comma collapsed every tag into one string.
+  private parseCachedTags(raw?: string | null): string[] {
+    if (!raw) return [];
+    return [...raw.matchAll(/ZZZ(.*?)ZZZ(?=\s|$)/g)].map((m) => m[1]).filter((t) => t.length > 0);
+  }
+
   async getAllDrafts(options?: {
     folder?: 'inbox' | 'archive' | 'trash' | 'all';
     flagged?: boolean;
@@ -94,7 +104,7 @@ export class DraftsDatabase {
       return results.map((row) => ({
         uuid: row.uuid,
         title: row.title || '',
-        tags: row.tags ? row.tags.split(',').filter((t: string) => t.trim()) : [],
+        tags: this.parseCachedTags(row.tags),
         createdAt: this.convertCocoaTimestamp(row.createdAt),
         modifiedAt: this.convertCocoaTimestamp(row.modifiedAt),
         isFlagged: row.isFlagged === 1,
@@ -161,7 +171,7 @@ export class DraftsDatabase {
       return results.map((row) => ({
         uuid: row.uuid,
         title: row.title || '',
-        tags: row.tags ? row.tags.split(',').filter((t: string) => t.trim()) : [],
+        tags: this.parseCachedTags(row.tags),
         createdAt: this.convertCocoaTimestamp(row.createdAt),
         modifiedAt: this.convertCocoaTimestamp(row.modifiedAt),
         isFlagged: row.isFlagged === 1,


### PR DESCRIPTION
## Motivation

`get_all_drafts` and `search_drafts_db` returned a draft tagged
`[mcp-test, automated, regression]` as a single mangled element:
`["ZZZmcp-testZZZ ZZZautomatedZZZ ZZZregressionZZZ"]`. The read path split
`ZCACHED_TAGS` on `,`, but Drafts stores it as space-separated `ZZZ<tag>ZZZ`
tokens, so the split never matched and the `ZZZ` sentinels leaked through.
Latent because every pre-existing draft in the store had empty tags.

## Implementation information

- New `parseCachedTags` helper used by both read paths. It extracts tag names
  from `ZZZ<tag>ZZZ` tokens, anchoring the closing `ZZZ` to a whitespace/end
  boundary (`/ZZZ(.*?)ZZZ(?=\s|$)/g`) so tags ending in `Z`, containing a
  literal `ZZZ`, or containing spaces (multi-word tags) parse correctly —
  the space is the authoritative separator, not `ZZZ`.
- The old test fixture seeded tags comma-separated (`'work,personal'`),
  encoding the buggy assumption; updated to the real `ZZZ`-token format.
- Added tests: multi-tag reads back clean with no `ZZZ` leak (getAllDrafts +
  searchDrafts), plus edge cases (trailing-`Z` tag, multi-word tag, embedded
  `ZZZ`). All fail against the old `split(',')` code.

Closes #48

> Changelog: fix(db): parse ZCACHED_TAGS ZZZ tokens