### PR TITLE
fix(db): escape uuid in getDraftContent query

### DIFF
--- a/src/__tests__/drafts-db.test.ts
+++ b/src/__tests__/drafts-db.test.ts
@@ -220,5 +220,17 @@ describe('DraftsDatabase', () => {
     it('returns null for a non-existent uuid', async () => {
       expect(await db.getDraftContent('does-not-exist')).toBeNull();
     });
+
+    it('does not allow SQL injection via a quote in the uuid', async () => {
+      // Unescaped, `' OR '1'='1` makes the WHERE always true and leaks a row.
+      // Escaped, it matches a literal uuid that does not exist -> null.
+      expect(await db.getDraftContent("' OR '1'='1")).toBeNull();
+    });
+
+    it('treats a quote-bearing uuid as a literal value, not SQL', async () => {
+      expect(await db.getDraftContent("uuid-multiline' --")).toBeNull();
+      // The legitimate lookup still works after escaping.
+      expect(await db.getDraftContent('uuid-multiline')).toBe('First line title\nsecond line');
+    });
   });
 });

--- a/src/drafts-db.ts
+++ b/src/drafts-db.ts
@@ -46,6 +46,14 @@ export class DraftsDatabase {
     return [...raw.matchAll(/ZZZ(.*?)ZZZ(?=\s|$)/g)].map((m) => m[1]).filter((t) => t.length > 0);
   }
 
+  // Escape a value for interpolation into a single-quoted SQLite string literal
+  // by doubling embedded single quotes. The sqlite3 CLI takes a raw SQL string,
+  // so every free-text value (uuid, search text) must be escaped to avoid
+  // breaking the query or allowing SQL injection.
+  private escapeSqlString(value: string): string {
+    return value.replace(/'/g, "''");
+  }
+
   async getAllDrafts(options?: {
     folder?: 'inbox' | 'archive' | 'trash' | 'all';
     flagged?: boolean;
@@ -122,7 +130,7 @@ export class DraftsDatabase {
     const query = `
       SELECT ZCONTENT as content
       FROM ZMANAGEDDRAFT
-      WHERE ZUUID = '${uuid}'
+      WHERE ZUUID = '${this.escapeSqlString(uuid)}'
     `;
 
     try {
@@ -158,8 +166,8 @@ export class DraftsDatabase {
         ZFLAGGED as isFlagged,
         ZFOLDER as folder
       FROM ZMANAGEDDRAFT
-      WHERE ZCONTENT LIKE '%${searchText.replace(/'/g, "''")}%'
-         OR ZTITLE LIKE '%${searchText.replace(/'/g, "''")}%'
+      WHERE ZCONTENT LIKE '%${this.escapeSqlString(searchText)}%'
+         OR ZTITLE LIKE '%${this.escapeSqlString(searchText)}%'
       ORDER BY ZMODIFIED_AT DESC
     `;
 


### PR DESCRIPTION
## Motivation

`getDraftContent` built its query with `WHERE ZUUID = '${uuid}'`, interpolating
the uuid raw. The uuid is model/tool-supplied (via the `get_draft` tool and the
unvalidated `draft://uuid/{uuid}` resource path), so a single quote broke the
query or injected SQL against the live local Drafts database. `searchDrafts`
already escaped quotes; `getDraftContent` did not.

## Implementation information

- Add a private `escapeSqlString` helper that doubles single quotes (SQLite's
  string-literal escape) and apply it at the query-builder chokepoint in
  `getDraftContent`, which also covers the unvalidated resource path.
- Refactor `searchDrafts`' two inline `.replace(/'/g,"''")` escapes to the same
  helper so the escaping rule lives in one place (no behavior change).
- Chose escaping over UUID-shape validation to stay consistent with the
  existing pattern and avoid false negatives on legitimate lookups.
- Tests: a `' OR '1'='1` uuid and a `--` comment-truncation uuid both return
  `null` (literal match, no injection), and a legitimate uuid still resolves.
  Both fail against the pre-fix code.

Closes #50

> Changelog: fix(db): escape uuid in getDraftContent query