### PR TITLE
feat(client): return new draft uuid from create

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Then point your client at the built entry point:
 
 | Tool | What it does |
 | --- | --- |
-| `create_draft` | Create a new draft with content, tags, and an optional action. |
+| `create_draft` | Create a new draft with content, tags, and an optional action. Returns the new draft's UUID. |
 | `get_draft` | Get a draft's full content by UUID (reads the local database). |
 | `get_all_drafts` | List all drafts with metadata, filtered by folder or flag. |
 | `search_drafts_db` | Full-text search your drafts in the local database. |

--- a/src/__tests__/drafts-client.test.ts
+++ b/src/__tests__/drafts-client.test.ts
@@ -66,6 +66,46 @@ describe('DraftsClient buildUrl encoding', () => {
   });
 });
 
+// Returns a canned x-success payload so we can assert createDraft surfaces
+// the uuid the Drafts callback hands back.
+class StubResponseClient extends DraftsClient {
+  constructor(
+    callbackServer: CallbackServer,
+    private response: Record<string, string>
+  ) {
+    super(callbackServer, { maxRetries: 1, retryDelay: 10 });
+  }
+  protected async openUrl(): Promise<Record<string, string>> {
+    return this.response;
+  }
+}
+
+describe('DraftsClient.createDraft return value', () => {
+  let callbackServer: CallbackServer;
+
+  beforeEach(async () => {
+    callbackServer = new CallbackServer();
+    await callbackServer.start();
+  });
+
+  afterEach(async () => {
+    await callbackServer.stop();
+  });
+
+  it('returns the uuid from the create callback', async () => {
+    const client = new StubResponseClient(callbackServer, { uuid: 'NEW-DRAFT-UUID' });
+    await expect(client.createDraft({ text: 'hi' })).resolves.toEqual({ uuid: 'NEW-DRAFT-UUID' });
+  });
+
+  it('returns an object with a uuid key even when the callback omits it', async () => {
+    const client = new StubResponseClient(callbackServer, {});
+    const result = await client.createDraft({ text: 'hi' });
+    // toEqual({uuid:undefined}) also matches {}, so assert the key is present.
+    expect(Object.keys(result)).toEqual(['uuid']);
+    expect(result.uuid).toBeUndefined();
+  });
+});
+
 describe('DraftsClient', () => {
   let callbackServer: CallbackServer;
   let draftsClient: DraftsClient;

--- a/src/drafts-client.ts
+++ b/src/drafts-client.ts
@@ -117,9 +117,12 @@ export class DraftsClient {
       });
 
       // The Drafts `create` x-success callback returns the new draft's uuid.
+      // It may be absent, so extract it explicitly as string | undefined
+      // rather than relying on the Record's index signature being present.
       const response = await this.openUrl(url, requestId);
+      const uuid: string | undefined = response.uuid;
 
-      return { uuid: response.uuid };
+      return { uuid };
     });
   }
 

--- a/src/drafts-client.ts
+++ b/src/drafts-client.ts
@@ -107,7 +107,7 @@ export class DraftsClient {
     tags?: string[];
     action?: string;
     folder?: 'inbox' | 'archive';
-  }): Promise<void> {
+  }): Promise<{ uuid?: string }> {
     return this.executeWithRetry(async () => {
       const { url, requestId } = this.buildUrl('create', {
         text: params.text,
@@ -116,7 +116,10 @@ export class DraftsClient {
         folder: params.folder,
       });
 
-      await this.openUrl(url, requestId);
+      // The Drafts `create` x-success callback returns the new draft's uuid.
+      const response = await this.openUrl(url, requestId);
+
+      return { uuid: response.uuid };
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,9 +272,14 @@ class DraftsMCPServer {
         switch (request.params.name) {
           case 'create_draft': {
             const args = CreateDraftSchema.parse(request.params.arguments);
-            await this.draftsClient.createDraft(args);
+            const { uuid } = await this.draftsClient.createDraft(args);
             return {
-              content: [{ type: 'text', text: 'Draft created successfully' }],
+              content: [
+                {
+                  type: 'text',
+                  text: uuid ? `Draft created: ${uuid}` : 'Draft created successfully',
+                },
+              ],
             };
           }
 


### PR DESCRIPTION
## Motivation

`create_draft` returned the static string `Draft created successfully` and
discarded the new draft's UUID. `DraftsClient.createDraft` awaited the
x-success callback but returned `void`, dropping the response data. Callers
could not chain `create -> append`/`prepend`/`get_draft` without a brittle
follow-up content search (substring match, can hit duplicates).

## Implementation information

- `createDraft` now returns `{ uuid?: string }`, read from the Drafts `create`
  x-success callback (key `uuid`, Drafts' default). The return type threads
  cleanly through `executeWithRetry<T>`.
- The `create_draft` tool handler surfaces it as `Draft created: <uuid>`,
  falling back to the old message if the callback omits a uuid.
- Keeps the x-success callback path intact (per the umbrella's constraint that
  #51 must not drop x-success).
- Tests: a stubbed callback asserts `createDraft` resolves to the uuid, and a
  missing-key case asserts the `uuid` key is still present (undefined). The
  present-uuid test fails against the old `void` return.
- README Tools table updated.

Closes #49

> Changelog: feat(client): return new draft uuid from create