### PR TITLE
fix(callback): reply 204 to suppress callback page

### DIFF
--- a/src/__tests__/callback-server.test.ts
+++ b/src/__tests__/callback-server.test.ts
@@ -26,7 +26,11 @@ describe('CallbackServer', () => {
     const callbacks = server.getCallbackUrls(requestId);
 
     // Simulate success callback
-    await fetch(`${callbacks.success}?text=hello&uuid=123`);
+    const httpRes = await fetch(`${callbacks.success}?text=hello&uuid=123`);
+
+    // 204 + empty body so macOS does not flash a browser page for the callback.
+    expect(httpRes.status).toBe(204);
+    expect(await httpRes.text()).toBe('');
 
     const response = await responsePromise;
 
@@ -44,7 +48,8 @@ describe('CallbackServer', () => {
     const callbacks = server.getCallbackUrls(requestId);
 
     // Simulate error callback
-    await fetch(`${callbacks.error}?error=Something went wrong`);
+    const httpRes = await fetch(`${callbacks.error}?error=Something went wrong`);
+    expect(httpRes.status).toBe(204);
 
     const response = await responsePromise;
 
@@ -59,7 +64,8 @@ describe('CallbackServer', () => {
     const callbacks = server.getCallbackUrls(requestId);
 
     // Simulate cancel callback
-    await fetch(callbacks.cancel);
+    const httpRes = await fetch(callbacks.cancel);
+    expect(httpRes.status).toBe(204);
 
     const response = await responsePromise;
 

--- a/src/__tests__/callback-server.test.ts
+++ b/src/__tests__/callback-server.test.ts
@@ -50,6 +50,7 @@ describe('CallbackServer', () => {
     // Simulate error callback
     const httpRes = await fetch(`${callbacks.error}?error=Something went wrong`);
     expect(httpRes.status).toBe(204);
+    expect(await httpRes.text()).toBe('');
 
     const response = await responsePromise;
 
@@ -66,6 +67,7 @@ describe('CallbackServer', () => {
     // Simulate cancel callback
     const httpRes = await fetch(callbacks.cancel);
     expect(httpRes.status).toBe(204);
+    expect(await httpRes.text()).toBe('');
 
     const response = await responsePromise;
 

--- a/src/callback-server.ts
+++ b/src/callback-server.ts
@@ -14,6 +14,17 @@ export class CallbackServer {
     this.setupRoutes();
   }
 
+  // Drafts opens the x-success/x-error/x-cancel URL after running the action,
+  // and macOS routes an http:// URL to the default browser. Reply 204 No Content
+  // with an empty body so the browser treats it as a no-op navigation and shows
+  // no page, instead of flashing an "OK" tab for every write. The query params
+  // are already captured before this runs, so the x-success data path is intact.
+  // (Eliminating the browser launch entirely would need a registered custom URL
+  // scheme owned by the MCP — see issue follow-up.)
+  private endSilently(res: Response): void {
+    res.status(204).end();
+  }
+
   private setupRoutes(): void {
     // Success callback handler
     this.app.get('/x-success/:requestId', (req: Request, res: Response) => {
@@ -34,7 +45,7 @@ export class CallbackServer {
         pending.resolve({ success: true, data });
       }
 
-      res.status(200).send('OK');
+      this.endSilently(res);
     });
 
     // Error callback handler
@@ -50,7 +61,7 @@ export class CallbackServer {
         pending.resolve({ success: false, error });
       }
 
-      res.status(200).send('OK');
+      this.endSilently(res);
     });
 
     // Cancel callback handler
@@ -64,7 +75,7 @@ export class CallbackServer {
         pending.resolve({ success: false, error: 'User cancelled' });
       }
 
-      res.status(200).send('OK');
+      this.endSilently(res);
     });
 
     // Health check


### PR DESCRIPTION
## Motivation

Every write/UI tool (`create_draft`, `append_to_draft`, `prepend_to_draft`,
`open_draft`, `run_action`, `search_drafts`) flashed the default browser with a
bare `OK` page. Drafts opens the `http://localhost:PORT/x-success/...` callback
after running the action; macOS routes the http URL to the default browser; the
callback server replied `200 OK`, so a tab rendered for every operation.

## Implementation information

- Reply `204 No Content` with an empty body on all three callback handlers
  (via `endSilently`) instead of `200 'OK'`. Browsers treat a 204 top-level
  navigation as a no-op, so no page renders.
- The query params (including the `create` UUID for #49) are captured and the
  pending request resolved **before** responding, so the x-success data path is
  fully intact — this does **not** drop `x-success`.
- Tests assert 204 + empty body on success/error/cancel while data still
  resolves.

## Scope / partial fix — please note

This is a **mitigation, not the full fix**. It suppresses the callback **page**,
but macOS still **launches/focuses the default browser** when Drafts opens the
http callback (the OS routes `http://` to the browser before our server can
respond). The visible flash is reduced (blank/no-op tab) but not eliminated.

Fully resolving #51's "resolve without launching a browser" needs **option 2**
from the issue: a private custom URL scheme registered to a helper the MCP owns,
so the OS routes the callback to that helper instead of the browser. That is a
packaging/architecture change (URL-scheme registration vs. the npm/.mcpb/binary
distribution), not a drop-in, so it should be a separate follow-up.

**Therefore this PR intentionally does not close #51** — it should stay open
(or spawn the option-2 follow-up) after this lands.

Partially addresses #51

> Changelog: fix(callback): reply 204 to suppress callback page