### PR TITLE
ci(actions): fix release artifact staging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,9 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add package.json package-lock.json src/version.ts mcpb/manifest.json
-          git commit -m "chore(release): v$VERSION"
+          # Tolerate a re-run where the version sources are already at $VERSION
+          # (e.g. recovering a release that failed after the bump commit landed).
+          git commit -m "chore(release): v$VERSION" || echo "version already at $VERSION"
           git tag "v$VERSION"
           git push origin HEAD:main
           git push origin "v$VERSION"
@@ -118,7 +120,8 @@ jobs:
       - name: Stage release artifacts at repo root
         run: |
           cp dist/drafts-mcp.mcpb "drafts-mcp-${VERSION}.mcpb"
-          cp mskalski-drafts-mcp-*.tgz .
+          # npm pack already wrote mskalski-drafts-mcp-<version>.tgz to the repo
+          # root, so it needs no copy (cp onto itself errors with "same file").
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,9 +84,15 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add package.json package-lock.json src/version.ts mcpb/manifest.json
-          # Tolerate a re-run where the version sources are already at $VERSION
-          # (e.g. recovering a release that failed after the bump commit landed).
-          git commit -m "chore(release): v$VERSION" || echo "version already at $VERSION"
+          # Skip the commit only when nothing is staged — i.e. a re-run where the
+          # version sources are already at $VERSION (recovering a release that
+          # failed after the bump commit landed). A real commit failure still
+          # fails the job rather than silently tagging the wrong commit.
+          if git diff --cached --quiet; then
+            echo "version sources already at $VERSION; skipping release commit"
+          else
+            git commit -m "chore(release): v$VERSION"
+          fi
           git tag "v$VERSION"
           git push origin HEAD:main
           git push origin "v$VERSION"


### PR DESCRIPTION
## Motivation

The 0.2.0 release run failed: the "Stage release artifacts" step ran
`cp mskalski-drafts-mcp-*.tgz .`, but `npm pack` already writes that tarball to
the repo root, so `cp` errored with *"are the same file"* (exit 1). The npm
publish and GitHub release jobs were skipped (the version bump + `v0.2.0` tag
had already been pushed).

## Implementation information

- Drop the redundant `cp …*.tgz .` — the tarball is already at the repo root
  where `upload-artifact` and the release job expect it.
- Make the release commit tolerate "nothing to commit" (`git commit … || echo`)
  so a release that failed after the bump commit landed can be re-run at the
  same version without the prepare job aborting on an empty commit.

## Validation

YAML edits preserve indentation; re-running the Release workflow for 0.2.0
after this lands is the real validation.

> Changelog: skip