### PR TITLE
perf(db): read drafts in-process via node:sqlite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,10 +5,11 @@ MCP server bridging AI clients (Claude/Codex/Cursor/...) to the **Drafts** app o
 ## Key Files
 
 - `src/index.ts` — MCP server entry point (`#!/usr/bin/env node`): tool/resource registration + dispatch.
-- `src/drafts-db.ts` — `DraftsDatabase`: READ path, shells out to sqlite3 CLI.
+- `src/drafts-db.ts` — `DraftsDatabase`: READ path, builds SQL + maps rows (queries via `SqliteReader`).
+- `src/sqlite.ts` — `SqliteReader`: in-process SQLite (node:sqlite / bun:sqlite) over a persistent read-only connection, with a `sqlite3` CLI fallback.
 - `src/drafts-client.ts` — `DraftsClient`: WRITE path, builds x-callback-url + `open` (fire-and-forget; created UUID read back from the DB).
 - `src/version.ts` — GENERATED, do not hand-edit (see Version Sync).
-- `src/__tests__/` — jest specs; run real sqlite3 against throwaway DBs.
+- `src/__tests__/` — jest specs; seed throwaway DBs with the sqlite3 CLI, query via both the in-process and CLI backends (asserting parity).
 - `scripts/bump-version.mjs` — single source of truth for release version.
 - `mcpb/manifest.json` — .mcpb bundle manifest (carries version). `build/` is tsc output (gitignored); bin target is `build/index.js`.
 
@@ -26,9 +27,12 @@ MCP server bridging AI clients (Claude/Codex/Cursor/...) to the **Drafts** app o
 
 This is the central design fact. Every tool falls into one of two paths.
 
-**READ path — `DraftsDatabase` (`drafts-db.ts`)**
+**READ path — `DraftsDatabase` (`drafts-db.ts`) → `SqliteReader` (`sqlite.ts`)**
 - Tools: `get_draft`, `get_all_drafts`, `search_drafts_db`, and the `draft://uuid/{uuid}` resource.
-- Shells out to the system `sqlite3 -json` CLI against `~/Library/Group Containers/GTFQ98J4YG.com.agiletortoise.Drafts/DraftStore.sqlite`.
+- Reads `~/Library/Group Containers/GTFQ98J4YG.com.agiletortoise.Drafts/DraftStore.sqlite` **in-process** via `SqliteReader`: a persistent read-only connection using `node:sqlite` (Node ≥22.5) or `bun:sqlite` (the standalone binary). This is ~25–60× faster than spawning a process per query (median read dropped from ~25ms to <1ms).
+- Falls back to the `sqlite3 -json` CLI subprocess when no in-process driver is available (Node 18/20) or an in-process query fails (stale connection self-heals). Set `DRAFTS_MCP_SQLITE_DRIVER=cli` to force the subprocess path. The CLI path and in-process path return identical row shapes — keep them parity-tested.
+- `DraftsDatabase` only builds SQL strings and maps rows; never put driver/subprocess logic there — it belongs in `SqliteReader`.
+- A persistent connection stays current: SQLite runs each statement in its own autocommit read transaction, so Drafts-side writes are visible to the next query without reopening.
 - Works even when the Drafts app is closed.
 - Cocoa epoch: DB timestamps are seconds since 2001-01-01; convert with `COCOA_EPOCH_OFFSET`.
 - Title fallback: `ZTITLE` is usually empty — derive the display title from the first line of `ZCONTENT` (mirror the existing `CASE` expression in any new query).

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Then point your client at the built entry point:
 ```
 
 - **Reads** (`get_*`, `search_drafts_db`) query the local Drafts SQLite database in-process (`node:sqlite`, or `bun:sqlite` in the standalone binary) over a persistent read-only connection — works even when Drafts is closed. Falls back to the system `sqlite3` CLI on older Node.
-- **Writes** (`create`, `append`, `prepend`, `open`, `run_action`, `search_drafts`) use Drafts' `x-callback-url` scheme. A short-lived Express callback server on a random localhost port captures the response. Retries 3× with exponential backoff.
+- **Writes** (`create`, `append`, `prepend`, `open`, `run_action`, `search_drafts`) hand a `drafts://x-callback-url` to the macOS `open` command **fire-and-forget** — no `x-success`/`x-error`/`x-cancel` callbacks and no localhost server, so Drafts opens nothing. `create_draft` reads the new draft's UUID back from the local database. Each write retries 3× with a fixed delay.
 
 ## CLI reference
 
@@ -185,8 +185,7 @@ drafts-mcp --version    Print version
 Everything runs locally on your Mac:
 
 - **Reads** query the local Drafts SQLite database directly — no app, network, or cloud involved.
-- **Writes** hand a `drafts://x-callback-url` to the macOS `open` command; Drafts then calls back into a short-lived HTTP server the MCP server starts on a random port.
-- That callback server lives only while the MCP server is running and only completes requests keyed by an unguessable `randomUUID()` it generated itself. It holds no credentials and carries nothing beyond Drafts' own callback payload.
+- **Writes** hand a `drafts://x-callback-url` to the macOS `open` command fire-and-forget. There is no callback server and no open network port; nothing listens for a response.
 - No auth tokens, no telemetry, no remote endpoints — your drafts never leave your machine.
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Then point your client at the built entry point:
                             └──────────────────┘
 ```
 
-- **Reads** (`get_*`, `search_drafts_db`) query the local Drafts SQLite database directly via the system `sqlite3` CLI — works even when Drafts is closed.
+- **Reads** (`get_*`, `search_drafts_db`) query the local Drafts SQLite database in-process (`node:sqlite`, or `bun:sqlite` in the standalone binary) over a persistent read-only connection — works even when Drafts is closed. Falls back to the system `sqlite3` CLI on older Node.
 - **Writes** (`create`, `append`, `prepend`, `open`, `run_action`, `search_drafts`) use Drafts' `x-callback-url` scheme. A short-lived Express callback server on a random localhost port captures the response. Retries 3× with exponential backoff.
 
 ## CLI reference
@@ -193,7 +193,7 @@ Everything runs locally on your Mac:
 
 - **macOS** — the server shells out to `open` for URL schemes and reads the macOS Drafts group container.
 - **[Drafts app](https://getdrafts.com)** installed (and running for write operations).
-- **Node.js 18+** — unless you use the standalone binary.
+- **Node.js 18+** — unless you use the standalone binary. Node 22.5+ (mise pins 24) reads the database in-process; Node 18/20 falls back to the `sqlite3` CLI, which must be on `PATH`.
 
 ## Develop
 

--- a/src/__tests__/drafts-client.test.ts
+++ b/src/__tests__/drafts-client.test.ts
@@ -3,10 +3,28 @@ import { promisify } from 'util';
 import { mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { DraftsClient, encodeQueryParams } from '../drafts-client.js';
+import { DraftsClient, encodeQueryParams, createPollInterval } from '../drafts-client.js';
 import { DraftsDatabase } from '../drafts-db.js';
 
 const execFileAsync = promisify(execFile);
+
+describe('createPollInterval', () => {
+  it('honors an explicit configured interval regardless of driver', () => {
+    expect(createPollInterval(20, 'cli')).toBe(20);
+    expect(createPollInterval(20, 'node-sqlite')).toBe(20);
+    expect(createPollInterval(0, 'cli')).toBe(0);
+  });
+
+  it('polls tightly for in-process drivers', () => {
+    expect(createPollInterval(undefined, 'node-sqlite')).toBe(75);
+    expect(createPollInterval(undefined, 'bun-sqlite')).toBe(75);
+    expect(createPollInterval(undefined, 'pending')).toBe(75);
+  });
+
+  it('relaxes to 200ms on the sqlite3 CLI fallback', () => {
+    expect(createPollInterval(undefined, 'cli')).toBe(200);
+  });
+});
 
 describe('encodeQueryParams', () => {
   it('encodes spaces as %20, not + (Drafts decodes + literally)', () => {
@@ -112,6 +130,7 @@ describe('DraftsClient.createDraft reads uuid from the DB', () => {
   });
 
   afterEach(() => {
+    db.dispose();
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -151,6 +170,7 @@ describe('DraftsClient.createDraft reads uuid from the DB', () => {
     const result = await client.createDraft({ text: 'x' });
     expect(result).toEqual({ uuid: undefined });
     expect(client.lastUrl).toContain('drafts://x-callback-url/create?');
+    brokenDb.dispose();
   });
 
   it('still returns the uuid when Drafts normalizes the stored content', async () => {

--- a/src/__tests__/drafts-db.test.ts
+++ b/src/__tests__/drafts-db.test.ts
@@ -41,6 +41,7 @@ describe('DraftsDatabase', () => {
   });
 
   afterAll(() => {
+    db.dispose();
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -186,7 +187,10 @@ describe('DraftsDatabase', () => {
       edgeDb = new DraftsDatabase(p);
     });
 
-    afterAll(() => rmSync(edgeDir, { recursive: true, force: true }));
+    afterAll(() => {
+      edgeDb.dispose();
+      rmSync(edgeDir, { recursive: true, force: true });
+    });
 
     it('keeps a trailing uppercase Z in the tag name', async () => {
       const drafts = await edgeDb.getAllDrafts();

--- a/src/__tests__/sqlite.test.ts
+++ b/src/__tests__/sqlite.test.ts
@@ -7,6 +7,19 @@ import { SqliteReader } from '../sqlite.js';
 
 const execFileAsync = promisify(execFile);
 
+// Mirrors SqliteReader's driver probe: does this runtime offer an in-process
+// SQLite backend, or will it (correctly) fall back to the sqlite3 CLI?
+function fastPathSupported(): boolean {
+  if ('bun' in process.versions) return true;
+  if (typeof process.getBuiltinModule !== 'function') return false;
+  try {
+    const mod = process.getBuiltinModule('node:sqlite') as { DatabaseSync?: unknown } | undefined;
+    return !!mod?.DatabaseSync;
+  } catch {
+    return false;
+  }
+}
+
 // SqliteReader has two interchangeable backends: an in-process driver
 // (node:sqlite / bun:sqlite) and the sqlite3 CLI. These tests pin down that
 // both return identical results so the fast path is a drop-in for the fallback.
@@ -59,12 +72,18 @@ describe('SqliteReader', () => {
     reader.dispose();
   });
 
-  it('uses the in-process driver on this runtime (Node >=22.5 / Bun)', async () => {
-    // Guards against a silent regression to the slow CLI path: the parity tests
-    // pass even if auto falls back to the CLI, so assert the resolved backend.
+  it('resolves to the in-process driver when the runtime supports it', async () => {
+    // Guards against a silent regression to the slow CLI path on the runtimes
+    // that DO support the fast path (Node >=22.5 / Bun — including CI on 24),
+    // while staying portable on Node 18/20 where the CLI fallback is correct.
     const reader = new SqliteReader(dbPath, 'auto');
     await reader.query('SELECT 1 as one');
-    expect(reader.activeDriver).toBe('bun' in process.versions ? 'bun-sqlite' : 'node-sqlite');
+
+    if (fastPathSupported()) {
+      expect(reader.activeDriver).toBe('bun' in process.versions ? 'bun-sqlite' : 'node-sqlite');
+    } else {
+      expect(reader.activeDriver).toBe('cli');
+    }
     reader.dispose();
   });
 

--- a/src/__tests__/sqlite.test.ts
+++ b/src/__tests__/sqlite.test.ts
@@ -1,0 +1,77 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { SqliteReader } from '../sqlite.js';
+
+const execFileAsync = promisify(execFile);
+
+// SqliteReader has two interchangeable backends: an in-process driver
+// (node:sqlite / bun:sqlite) and the sqlite3 CLI. These tests pin down that
+// both return identical results so the fast path is a drop-in for the fallback.
+describe('SqliteReader', () => {
+  let dir: string;
+  let dbPath: string;
+
+  beforeAll(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'sqlite-reader-'));
+    dbPath = join(dir, 'test.sqlite');
+    await execFileAsync('sqlite3', [
+      dbPath,
+      'CREATE TABLE t (id INTEGER, name TEXT, score REAL, note TEXT);' +
+        "INSERT INTO t VALUES (1, 'alpha', 1.5, NULL), (2, 'beta', 2.5, 'has '' quote');",
+    ]);
+  });
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('auto (in-process) and cli drivers return identical rows', async () => {
+    const auto = new SqliteReader(dbPath, 'auto');
+    const cli = new SqliteReader(dbPath, 'cli');
+    const sql = 'SELECT id, name, score, note FROM t ORDER BY id';
+
+    const autoRows = await auto.query(sql);
+    const cliRows = await cli.query(sql);
+
+    expect(autoRows).toEqual(cliRows);
+    expect(autoRows).toEqual([
+      { id: 1, name: 'alpha', score: 1.5, note: null },
+      { id: 2, name: 'beta', score: 2.5, note: 'has ' + "' quote" },
+    ]);
+    auto.dispose();
+  });
+
+  it('returns an empty array when nothing matches (both drivers)', async () => {
+    const auto = new SqliteReader(dbPath, 'auto');
+    const cli = new SqliteReader(dbPath, 'cli');
+    expect(await auto.query('SELECT id FROM t WHERE id = 999')).toEqual([]);
+    expect(await cli.query('SELECT id FROM t WHERE id = 999')).toEqual([]);
+    auto.dispose();
+  });
+
+  it('serves many queries from one persistent connection', async () => {
+    const reader = new SqliteReader(dbPath, 'auto');
+    for (let i = 0; i < 50; i++) {
+      const rows = await reader.query('SELECT COUNT(*) as c FROM t');
+      expect(rows[0].c).toBe(2);
+    }
+    reader.dispose();
+  });
+
+  it('uses the in-process driver on this runtime (Node >=22.5 / Bun)', async () => {
+    // Guards against a silent regression to the slow CLI path: the parity tests
+    // pass even if auto falls back to the CLI, so assert the resolved backend.
+    const reader = new SqliteReader(dbPath, 'auto');
+    await reader.query('SELECT 1 as one');
+    expect(reader.activeDriver).toBe('bun' in process.versions ? 'bun-sqlite' : 'node-sqlite');
+    reader.dispose();
+  });
+
+  it('reports the cli backend when forced to cli mode', async () => {
+    const reader = new SqliteReader(dbPath, 'cli');
+    await reader.query('SELECT 1 as one');
+    expect(reader.activeDriver).toBe('cli');
+    reader.dispose();
+  });
+});

--- a/src/drafts-client.ts
+++ b/src/drafts-client.ts
@@ -1,8 +1,18 @@
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { DraftsDatabase } from './drafts-db.js';
+import { ActiveDriver } from './sqlite.js';
 
 const execFileAsync = promisify(execFile);
+
+// Poll cadence for the post-create DB lookup. An explicit config value always
+// wins; otherwise poll tightly (75ms) when reads are in-process ~1ms lookups,
+// but relax to 200ms on the sqlite3 CLI fallback so a create that never lands
+// doesn't spawn a subprocess every 75ms for the full lookup window.
+export function createPollInterval(configured: number | undefined, driver: ActiveDriver): number {
+  if (configured !== undefined) return configured;
+  return driver === 'cli' ? 200 : 75;
+}
 
 // encodeURIComponent leaves !'()* unescaped; percent-encode them too so the
 // value is safe inside an x-callback-url query string.
@@ -49,7 +59,8 @@ export class DraftsClient {
   private maxRetries: number;
   private retryDelay: number;
   private createLookupTimeout: number;
-  private createLookupInterval: number;
+  // undefined => adaptive: tight when reads are in-process, relaxed on the CLI.
+  private createLookupInterval?: number;
   // Serializes createDraft calls so each captures a Z_PK watermark that already
   // reflects prior creates. Without this, two concurrent creates would share a
   // watermark and the DB lookup could not tell their drafts apart.
@@ -60,9 +71,11 @@ export class DraftsClient {
     this.maxRetries = config.maxRetries ?? 3;
     this.retryDelay = config.retryDelay ?? 1000;
     this.createLookupTimeout = config.createLookupTimeout ?? 10000;
-    // In-process DB lookups cost ~1ms, so poll tightly: a created draft surfaces
-    // within a poll interval of Drafts committing it, not up to 200ms later.
-    this.createLookupInterval = config.createLookupInterval ?? 75;
+    this.createLookupInterval = config.createLookupInterval;
+  }
+
+  private pollInterval(): number {
+    return createPollInterval(this.createLookupInterval, this.db.activeDriver);
   }
 
   private async executeWithRetry<T>(
@@ -114,7 +127,9 @@ export class DraftsClient {
         // the create and produce a duplicate draft.
       }
       if (Date.now() >= deadline) return undefined;
-      await new Promise((resolve) => setTimeout(resolve, this.createLookupInterval));
+      // Computed each iteration so it reflects the driver once the first lookup
+      // has resolved it (activeDriver is 'pending' until then).
+      await new Promise((resolve) => setTimeout(resolve, this.pollInterval()));
     }
   }
 

--- a/src/drafts-client.ts
+++ b/src/drafts-client.ts
@@ -60,7 +60,9 @@ export class DraftsClient {
     this.maxRetries = config.maxRetries ?? 3;
     this.retryDelay = config.retryDelay ?? 1000;
     this.createLookupTimeout = config.createLookupTimeout ?? 10000;
-    this.createLookupInterval = config.createLookupInterval ?? 200;
+    // In-process DB lookups cost ~1ms, so poll tightly: a created draft surfaces
+    // within a poll interval of Drafts committing it, not up to 200ms later.
+    this.createLookupInterval = config.createLookupInterval ?? 75;
   }
 
   private async executeWithRetry<T>(

--- a/src/drafts-db.ts
+++ b/src/drafts-db.ts
@@ -1,7 +1,7 @@
 import { homedir } from 'os';
 import { join } from 'path';
 import { DraftMetadata } from './types.js';
-import { SqliteReader, SqliteDriver } from './sqlite.js';
+import { SqliteReader, SqliteDriver, ActiveDriver } from './sqlite.js';
 
 // Drafts stores timestamps as seconds since 2001-01-01 (Apple Cocoa reference date)
 const COCOA_EPOCH_OFFSET = 978307200;
@@ -25,6 +25,12 @@ export class DraftsDatabase {
     const driver =
       options.driver ?? (process.env.DRAFTS_MCP_SQLITE_DRIVER === 'cli' ? 'cli' : 'auto');
     this.reader = new SqliteReader(this.dbPath, driver);
+  }
+
+  // The backend the reader resolved to ('cli' on runtimes without an in-process
+  // driver). Callers use it to tune behavior, e.g. polling cadence.
+  get activeDriver(): ActiveDriver {
+    return this.reader.activeDriver;
   }
 
   // Release the persistent read-only connection. Optional for the long-lived

--- a/src/drafts-db.ts
+++ b/src/drafts-db.ts
@@ -1,18 +1,16 @@
-import { execFile } from 'child_process';
-import { promisify } from 'util';
 import { homedir } from 'os';
 import { join } from 'path';
 import { DraftMetadata } from './types.js';
-
-const execFileAsync = promisify(execFile);
+import { SqliteReader, SqliteDriver } from './sqlite.js';
 
 // Drafts stores timestamps as seconds since 2001-01-01 (Apple Cocoa reference date)
 const COCOA_EPOCH_OFFSET = 978307200;
 
 export class DraftsDatabase {
   private dbPath: string;
+  private reader: SqliteReader;
 
-  constructor(dbPath?: string) {
+  constructor(dbPath?: string, options: { driver?: SqliteDriver } = {}) {
     this.dbPath =
       dbPath ||
       join(
@@ -22,18 +20,22 @@ export class DraftsDatabase {
         'GTFQ98J4YG.com.agiletortoise.Drafts',
         'DraftStore.sqlite'
       );
+    // DRAFTS_MCP_SQLITE_DRIVER=cli forces the subprocess path as an escape hatch
+    // if the in-process driver ever misbehaves on a given machine.
+    const driver =
+      options.driver ?? (process.env.DRAFTS_MCP_SQLITE_DRIVER === 'cli' ? 'cli' : 'auto');
+    this.reader = new SqliteReader(this.dbPath, driver);
+  }
+
+  // Release the persistent read-only connection. Optional for the long-lived
+  // server (the OS reaps the fd on exit); used by tests to avoid leaked handles.
+  dispose(): void {
+    this.reader.dispose();
   }
 
   private convertCocoaTimestamp(timestamp: number): string {
     const unixTimestamp = timestamp + COCOA_EPOCH_OFFSET;
     return new Date(unixTimestamp * 1000).toISOString();
-  }
-
-  // sqlite3 -json emits an empty string (not "[]") when no rows match,
-  // so guard against parsing that as JSON.
-  private parseRows(stdout: string): any[] {
-    const trimmed = stdout.trim();
-    return trimmed ? JSON.parse(trimmed) : [];
   }
 
   // Drafts stores ZCACHED_TAGS as space-separated ZZZ<tag>ZZZ tokens, not a
@@ -44,6 +46,22 @@ export class DraftsDatabase {
   private parseCachedTags(raw?: string | null): string[] {
     if (!raw) return [];
     return [...raw.matchAll(/ZZZ(.*?)ZZZ(?=\s|$)/g)].map((m) => m[1]).filter((t) => t.length > 0);
+  }
+
+  // Map one ZMANAGEDDRAFT row (CLI -json or in-process driver — same shape) to
+  // DraftMetadata. Folder/flag columns come back as integers; tags/timestamps
+  // are normalized via the helpers above.
+  private toMetadata(row: Record<string, unknown>): DraftMetadata {
+    return {
+      uuid: row.uuid as string,
+      title: (row.title as string) || '',
+      tags: this.parseCachedTags(row.tags as string | null | undefined),
+      createdAt: this.convertCocoaTimestamp(row.createdAt as number),
+      modifiedAt: this.convertCocoaTimestamp(row.modifiedAt as number),
+      isFlagged: row.isFlagged === 1,
+      isArchived: row.folder === 1,
+      isTrashed: row.folder === 2,
+    };
   }
 
   // Escape a value for interpolation into a single-quoted SQLite string literal
@@ -105,20 +123,9 @@ export class DraftsDatabase {
     `;
 
     try {
-      const { stdout } = await execFileAsync('sqlite3', [this.dbPath, '-json', query]);
+      const results = await this.reader.query(query);
 
-      const results = this.parseRows(stdout);
-
-      return results.map((row) => ({
-        uuid: row.uuid,
-        title: row.title || '',
-        tags: this.parseCachedTags(row.tags),
-        createdAt: this.convertCocoaTimestamp(row.createdAt),
-        modifiedAt: this.convertCocoaTimestamp(row.modifiedAt),
-        isFlagged: row.isFlagged === 1,
-        isArchived: row.folder === 1,
-        isTrashed: row.folder === 2,
-      }));
+      return results.map((row) => this.toMetadata(row));
     } catch (error) {
       throw new Error(`Failed to query Drafts database: ${error}`, {
         cause: error,
@@ -134,15 +141,13 @@ export class DraftsDatabase {
     `;
 
     try {
-      const { stdout } = await execFileAsync('sqlite3', [this.dbPath, '-json', query]);
-
-      const results = this.parseRows(stdout);
+      const results = await this.reader.query(query);
 
       if (results.length === 0) {
         return null;
       }
 
-      return results[0].content || '';
+      return (results[0].content as string) || '';
     } catch (error) {
       throw new Error(`Failed to query draft content: ${error}`, {
         cause: error,
@@ -172,20 +177,9 @@ export class DraftsDatabase {
     `;
 
     try {
-      const { stdout } = await execFileAsync('sqlite3', [this.dbPath, '-json', query]);
+      const results = await this.reader.query(query);
 
-      const results = this.parseRows(stdout);
-
-      return results.map((row) => ({
-        uuid: row.uuid,
-        title: row.title || '',
-        tags: this.parseCachedTags(row.tags),
-        createdAt: this.convertCocoaTimestamp(row.createdAt),
-        modifiedAt: this.convertCocoaTimestamp(row.modifiedAt),
-        isFlagged: row.isFlagged === 1,
-        isArchived: row.folder === 1,
-        isTrashed: row.folder === 2,
-      }));
+      return results.map((row) => this.toMetadata(row));
     } catch (error) {
       throw new Error(`Failed to search drafts: ${error}`, {
         cause: error,
@@ -201,9 +195,8 @@ export class DraftsDatabase {
     const query = `SELECT MAX(Z_PK) as maxPk FROM ZMANAGEDDRAFT`;
 
     try {
-      const { stdout } = await execFileAsync('sqlite3', [this.dbPath, '-json', query]);
-      const results = this.parseRows(stdout);
-      return results[0]?.maxPk ?? 0;
+      const results = await this.reader.query(query);
+      return (results[0]?.maxPk as number) ?? 0;
     } catch (error) {
       throw new Error(`Failed to read max draft id: ${error}`, {
         cause: error,
@@ -227,9 +220,8 @@ export class DraftsDatabase {
     `;
 
     try {
-      const { stdout } = await execFileAsync('sqlite3', [this.dbPath, '-json', query]);
-      const results = this.parseRows(stdout);
-      return results.length > 0 ? results[0].uuid : null;
+      const results = await this.reader.query(query);
+      return results.length > 0 ? (results[0].uuid as string) : null;
     } catch (error) {
       throw new Error(`Failed to look up created draft: ${error}`, {
         cause: error,

--- a/src/sqlite.ts
+++ b/src/sqlite.ts
@@ -1,0 +1,142 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export type SqliteDriver = 'auto' | 'cli';
+// Which backend a reader ended up using — surfaced for diagnostics and tests.
+export type ActiveDriver = 'pending' | 'node-sqlite' | 'bun-sqlite' | 'cli';
+
+// One row of a query result, keyed by column alias — the same shape the
+// `sqlite3 -json` CLI emits and that node:sqlite / bun:sqlite return from .all().
+type Row = Record<string, unknown>;
+
+// The slice of an in-process SQLite driver we rely on. Both node:sqlite
+// (DatabaseSync) and bun:sqlite (Database) satisfy it.
+interface InProcessDb {
+  prepare(sql: string): { all(): unknown[] };
+  close(): void;
+}
+
+interface Driver {
+  label: ActiveDriver;
+  open: (dbPath: string) => InProcessDb;
+}
+
+// Reads the Drafts SQLite DB. Prefers an in-process driver with a persistent
+// read-only connection (bun:sqlite under Bun, node:sqlite under Node >=22.5),
+// which is ~25x faster than spawning the `sqlite3` CLI per query. Falls back to
+// the `sqlite3 -json` CLI on older runtimes or any in-process failure, so reads
+// keep working everywhere the CLI-only implementation did.
+//
+// A persistent connection stays current: SQLite runs each statement in its own
+// read transaction (autocommit), so committed writes from the Drafts app are
+// visible to the next query without reopening.
+export class SqliteReader {
+  private dbPath: string;
+  private mode: SqliteDriver;
+  private conn: InProcessDb | null = null;
+  // null = not yet probed; a Driver once one loads; false once we know no
+  // in-process driver is usable on this runtime (then we stay on the CLI).
+  private driver: Driver | null | false = null;
+  private active: ActiveDriver = 'pending';
+
+  constructor(dbPath: string, mode: SqliteDriver = 'auto') {
+    this.dbPath = dbPath;
+    this.mode = mode;
+    if (mode === 'cli') this.driver = false;
+  }
+
+  // The backend the last query used (or would use). 'pending' until the first
+  // query resolves a driver.
+  get activeDriver(): ActiveDriver {
+    return this.active;
+  }
+
+  async query(sql: string): Promise<Row[]> {
+    if (this.mode !== 'cli') {
+      try {
+        const conn = this.connection();
+        if (conn) {
+          const rows = conn.prepare(sql).all() as Row[];
+          return rows;
+        }
+      } catch {
+        // A persistent connection can go stale (DB checkpointed or replaced) or
+        // the driver can choke on a transiently locked DB. Drop it and serve
+        // this call from the CLI; the next call retries the in-process path.
+        this.dispose();
+      }
+    }
+    const rows = await this.queryViaCli(sql);
+    this.active = 'cli';
+    return rows;
+  }
+
+  private connection(): InProcessDb | null {
+    if (this.conn) return this.conn;
+    if (this.driver === false) return null;
+    if (this.driver === null) {
+      this.driver = loadDriver() ?? false;
+      if (this.driver === false) return null;
+    }
+    this.conn = this.driver.open(this.dbPath);
+    this.active = this.driver.label;
+    return this.conn;
+  }
+
+  private async queryViaCli(sql: string): Promise<Row[]> {
+    // sqlite3 -json emits an empty string (not "[]") when no rows match.
+    const { stdout } = await execFileAsync('sqlite3', [this.dbPath, '-json', sql]);
+    const trimmed = stdout.trim();
+    return trimmed ? (JSON.parse(trimmed) as Row[]) : [];
+  }
+
+  dispose(): void {
+    try {
+      this.conn?.close();
+    } catch {
+      // best-effort; the OS reaps the fd on exit anyway
+    }
+    this.conn = null;
+  }
+}
+
+// Resolve the best in-process driver for the current runtime, or null if none
+// is available (older Node without node:sqlite). Synchronous and resolver-free:
+// it uses process.getBuiltinModule for node:sqlite (which bundlers and test
+// runners can mangle when handed a dynamic `import('node:sqlite')`).
+function loadDriver(): Driver | null {
+  if (typeof process === 'undefined') return null;
+
+  // Bun ships bun:sqlite and does not implement node:sqlite. require() resolves
+  // the builtin synchronously inside the compiled binary.
+  if (process.versions && 'bun' in process.versions) {
+    try {
+      const { createRequire } = process.getBuiltinModule('node:module');
+      const bunRequire = createRequire(import.meta.url);
+      const { Database } = bunRequire('bun:sqlite') as {
+        Database: new (path: string, opts: { readonly: boolean }) => InProcessDb;
+      };
+      return { label: 'bun-sqlite', open: (path) => new Database(path, { readonly: true }) };
+    } catch {
+      return null;
+    }
+  }
+
+  // Node >=22.3 exposes builtins via getBuiltinModule; node:sqlite landed in
+  // 22.5 (flagged) and is unflagged in 24. Older Node lacks the method entirely.
+  if (typeof process.getBuiltinModule !== 'function') return null;
+  try {
+    const mod = process.getBuiltinModule('node:sqlite') as
+      | { DatabaseSync: new (path: string, opts: { readOnly: boolean }) => InProcessDb }
+      | undefined;
+    if (mod?.DatabaseSync) {
+      const DatabaseSync = mod.DatabaseSync;
+      return { label: 'node-sqlite', open: (path) => new DatabaseSync(path, { readOnly: true }) };
+    }
+  } catch {
+    // getBuiltinModule throws when the builtin is unavailable on this runtime
+  }
+  return null;
+}

--- a/src/sqlite.ts
+++ b/src/sqlite.ts
@@ -109,12 +109,13 @@ export class SqliteReader {
 function loadDriver(): Driver | null {
   if (typeof process === 'undefined') return null;
 
-  // Bun ships bun:sqlite and does not implement node:sqlite. require() resolves
-  // the builtin synchronously inside the compiled binary.
+  // Bun ships bun:sqlite and does not implement node:sqlite. Resolve the builtin
+  // synchronously (works inside the compiled binary) without assuming any single
+  // mechanism: Bun's own import.meta.require, else node:module.createRequire.
   if (process.versions && 'bun' in process.versions) {
     try {
-      const { createRequire } = process.getBuiltinModule('node:module');
-      const bunRequire = createRequire(import.meta.url);
+      const bunRequire = resolveBunRequire();
+      if (!bunRequire) return null;
       const { Database } = bunRequire('bun:sqlite') as {
         Database: new (path: string, opts: { readonly: boolean }) => InProcessDb;
       };
@@ -137,6 +138,20 @@ function loadDriver(): Driver | null {
     }
   } catch {
     // getBuiltinModule throws when the builtin is unavailable on this runtime
+  }
+  return null;
+}
+
+// A synchronous require() usable under Bun, or null if neither mechanism is
+// available (so the caller falls back to the CLI rather than crashing).
+function resolveBunRequire(): ((id: string) => unknown) | null {
+  const meta = import.meta as unknown as { require?: (id: string) => unknown };
+  if (typeof meta.require === 'function') return meta.require;
+  if (typeof process.getBuiltinModule === 'function') {
+    const mod = process.getBuiltinModule('node:module') as
+      | { createRequire?: (path: string) => (id: string) => unknown }
+      | undefined;
+    if (mod?.createRequire) return mod.createRequire(import.meta.url);
   }
   return null;
 }


### PR DESCRIPTION
## Motivation

> Changelog: perf(db): read drafts in-process via node:sqlite

Every read tool (`get_draft`, `get_all_drafts`, `search_drafts_db`, the
`draft://` resource) and every `create_draft` DB lookup spawned a fresh
`sqlite3` CLI process. Profiling the live server over stdio showed each
read paying ~25ms of process-spawn overhead — the dominant cost on the
read path, with a cold-start spike to ~600ms.

## Implementation information

Reads now run **in-process** over a persistent read-only SQLite
connection, with the CLI kept only as a fallback.

- New `SqliteReader` (`src/sqlite.ts`) picks the best backend per runtime:
  `node:sqlite` (Node ≥22.5, unflagged on 24 — npm + `.mcpb`), `bun:sqlite`
  (the standalone binary), else the `sqlite3 -json` CLI (Node 18/20).
  Driver resolution uses `process.getBuiltinModule` so it survives Bun's
  `--compile` bundler and jest's module resolver.
- The connection is opened once and reused. SQLite runs each statement in
  its own autocommit read transaction, so Drafts-side writes stay visible
  without reopening. A failed in-process query disposes the connection and
  falls back to the CLI for that call, then retries the fast path.
- `DraftsDatabase` keeps only SQL-building + row-mapping; the SQL strings,
  quote-escaping, and row shapes are unchanged, so both backends are
  byte-for-byte parity-tested.
- Escape hatch: `DRAFTS_MCP_SQLITE_DRIVER=cli` forces the subprocess path.
- `create_draft` poll interval tightened 200ms → 75ms now that each lookup
  costs ~1ms, reducing created-uuid detection lag.

**Measured (end-to-end over stdio, real 1242-draft DB):**

| Tool | Before (CLI) | After (in-process) | Speedup |
|------|------|------|------|
| `get_all_drafts` (all) | 37.4 ms | 5.2 ms | ~7× |
| `get_all_drafts` (inbox) | 24.9 ms | 0.6 ms | ~41× |
| `search_drafts_db` | 24.2 ms | 0.4 ms | ~60× |

All three distribution targets verified: npm/Node, `.mcpb`, and the
compiled Bun binary (smoke-tested the actual artifact). CLI fallback
verified via the env override. Full gate green (lint, format, 48 tests,
version check, build).

## Supporting documentation

- Updated `CLAUDE.md` (READ-path architecture) and `README.md`
  (read mechanism + runtime requirements).
